### PR TITLE
Fix XBM to parse #defines correctly.

### DIFF
--- a/image/xbm/reader.go
+++ b/image/xbm/reader.go
@@ -99,7 +99,7 @@ func (d *decoder) readHeader() {
 		}
 		switch f[0] {
 		case "#define":
-			if iu := strings.LastIndex(f[1], "_"); iu != -1 {
+			if iu := strings.Index(f[1], "_"); iu != -1 {
 				s := f[1][:iu]
 				switch name {
 				case "":


### PR DESCRIPTION
I found this XBM file on the net:

/\* (circles.xbm) */
# define icon_width 16
# define icon_height 16
# define icon_x_hot 4
# define icon_y_hot 4

static char icon_bits[] = {
  0x00, 0x00, 0x7c, 0x00, 0x82, 0x00, 0x82, 0x00,
  0x82, 0x00, 0x82, 0x00, 0x82, 0x00, 0x7c, 0x3e,
  0x00, 0x41, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
  0x80, 0x80, 0x80, 0x80, 0x00, 0x41, 0x00, 0x3e };

I had to change the parsing of #define to get it to load. 
